### PR TITLE
Migrate to pytorch-transformers 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This model should give a Hits@1 over 79, perplexity of 20.5 and F1 of 16.5 using
 
 These numbers are slightly lower than the number we obtained in the ConvAI2 competition. Here is what you can tweak to reach the same results:
 
-- in the ConvAI2 competition we also used tweaked position emebddings so that the history of the dialog always start at with the same embeddings. This is easy to add with pytorch-pretrained-bert and should improve the hits@1 metric.
+- in the ConvAI2 competition we also used tweaked position emebddings so that the history of the dialog always start at with the same embeddings. This is easy to add with pytorch-transformers and should improve the hits@1 metric.
 - in the ConvAI2 competition we used a beam search decoder. While the results are better in term of f1 metric, our feeling is that the human experience is les compelling with beam search versus the nucleus sampling detector which is provided in the present repository.
 
 ## Using the interaction script

--- a/convai_evaluation.py
+++ b/convai_evaluation.py
@@ -17,7 +17,7 @@ from projects.convai2.eval_hits import eval_hits, setup_args as setup_args_hits
 from projects.convai2.eval_f1 import eval_f1, setup_args as setup_args_f1
 from projects.convai2.eval_ppl import eval_ppl, setup_args as setup_args_ppl
 from projects.convai2.build_dict import build_dict
-from pytorch_pretrained_bert import OpenAIGPTDoubleHeadsModel, OpenAIGPTLMHeadModel, OpenAIGPTTokenizer
+from pytorch_transformers import OpenAIGPTDoubleHeadsModel, OpenAIGPTLMHeadModel, OpenAIGPTTokenizer
 
 from train import build_input_from_segments, pad_dataset, SPECIAL_TOKENS
 from utils import download_pretrained_model, AttrDict
@@ -64,7 +64,6 @@ class TransformerAgent(Agent):
             else:
                 self.model_checkpoint = OpenAIGPTLMHeadModel.from_pretrained(args.model_checkpoint)
             self.model_checkpoint.to(args.device)
-            self.model_checkpoint.eval()
 
             self.logger.info("Build BPE prefix dictionary")
             convai_dict = build_dict()

--- a/convai_evaluation.py
+++ b/convai_evaluation.py
@@ -27,7 +27,7 @@ class TransformerAgent(Agent):
     @staticmethod
     def add_cmdline_args(argparser):
         agent_args = argparser.add_argument_group('Agent parameters')
-        agent_args.add_argument("--model_checkpoint", type=str, default="", help="Path, url or short name of the model")
+        agent_args.add_argument("--model_checkpoint", type=str, default="", help="Path, url or short name of the model. Must be OpenAIGPT.")
         agent_args.add_argument("--max_history", type=int, default=2, help="Number of previous utterances to keep in history")
         agent_args.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu", help="Device (cuda or cpu)")
         agent_args.add_argument("--eval_type", type=str, default="hits@1", help="hits@1, ppl or f1")

--- a/interact.py
+++ b/interact.py
@@ -7,6 +7,7 @@ import random
 from argparse import ArgumentParser
 from itertools import chain
 from pprint import pformat
+import warnings
 
 import torch
 import torch.nn.functional as F
@@ -75,8 +76,10 @@ def sample_sequence(personality, history, tokenizer, model, args, current_output
         prev = torch.topk(probs, 1)[1] if args.no_sample else torch.multinomial(probs, 1)
         if i < args.min_length and prev.item() in special_tokens_ids:
             while prev.item() in special_tokens_ids:
+                if probs.max().item() == 1:
+                    warnings.warn("Warning: model generating special token with probability 1.")
+                    break  # avoid infinitely looping over special token
                 prev = torch.multinomial(probs, num_samples=1)
-                if probs.max().item() == 1: break
 
         if prev.item() in special_tokens_ids:
             break

--- a/interact.py
+++ b/interact.py
@@ -65,7 +65,7 @@ def sample_sequence(personality, history, tokenizer, model, args, current_output
         input_ids = torch.tensor(instance["input_ids"], device=args.device).unsqueeze(0)
         token_type_ids = torch.tensor(instance["token_type_ids"], device=args.device).unsqueeze(0)
 
-        logits, = model(input_ids, token_type_ids=token_type_ids)
+        logits = model(input_ids, token_type_ids=token_type_ids)
         if isinstance(logits, tuple):  # for gpt2 and maybe others
             logits = logits[0]
         logits = logits[0, -1, :] / args.temperature

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
 pytorch-ignite
-pytorch-pretrained-bert >= 0.6.2
-tensorboardX
+pytorch-transformers>=1.2
+git+https://github.com/lanpa/tensorboardX
 tensorflow  # for tensorboardX

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
 pytorch-ignite
 pytorch-transformers>=1.2
-git+https://github.com/lanpa/tensorboardX
+tensorboardX==1.8
 tensorflow  # for tensorboardX

--- a/test_special_tokens.py
+++ b/test_special_tokens.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import shutil
+import unittest
+
+from pytorch_transformers import OpenAIGPTTokenizer, GPT2Tokenizer
+from train import ATTR_TO_SPECIAL_TOKEN, SPECIAL_TOKENS
+
+class TestSpecialTokenTreatment(unittest.TestCase):
+
+    def setUp(self):
+        self.save_dir = Path('utest_save_dir')
+        self.save_dir.mkdir(exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.save_dir)
+
+    def test_special_tokens_checkpoint_behavior(self):
+        toks = [OpenAIGPTTokenizer.from_pretrained('openai-gpt'), GPT2Tokenizer.from_pretrained('gpt2')]
+        for tok in toks:
+            self.assertEqual(len(tok.added_tokens_encoder), 0)
+            tok.add_special_tokens(ATTR_TO_SPECIAL_TOKEN)
+            self.assertEqual(len(tok.added_tokens_encoder), 5)
+            # Make sure we never split
+            self.assertEqual(len(tok.tokenize("<bos> <speaker1>")), 2)
+            ids = tok.convert_tokens_to_ids(SPECIAL_TOKENS)
+            self.assertTrue(all([x > 0 for x in ids]),
+                            f'some tokens failed to tokenize {SPECIAL_TOKENS} -> {ids}')
+            # Need to mantain indices through save. (this is also tested in pytorch-transformers)
+            tok.save_pretrained(self.save_dir)
+            tok_loaded = tok.from_pretrained(str(self.save_dir))
+            ids2 = tok_loaded.convert_tokens_to_ids(SPECIAL_TOKENS)
+            self.assertListEqual(ids, ids2)

--- a/train.py
+++ b/train.py
@@ -19,7 +19,7 @@ from ignite.contrib.handlers.tensorboard_logger import TensorboardLogger, Output
 from pytorch_transformers import (AdamW, OpenAIGPTDoubleHeadsModel, OpenAIGPTTokenizer,
                                   GPT2DoubleHeadsModel, GPT2Tokenizer, WEIGHTS_NAME, CONFIG_NAME)
 
-from utils import get_dataset
+from utils import get_dataset, make_logdir
 
 SPECIAL_TOKENS = ["<bos>", "<eos>", "<speaker1>", "<speaker2>", "<pad>"]
 ATTR_TO_SPECIAL_TOKEN = {'bos_token': '<bos>', 'eos_token': '<eos>', 'pad_token': '<pad>',
@@ -245,8 +245,9 @@ def train():
         pbar.attach(trainer, metric_names=["loss"])
         evaluator.add_event_handler(Events.COMPLETED, lambda _: pbar.log_message("Validation: %s" % pformat(evaluator.state.metrics)))
 
-        tb_logger = TensorboardLogger(log_dir=None)
-        log_dir = tb_logger.writer.logdir  # to save typing
+        log_dir = make_logdir(args.model_checkpoint)
+        tb_logger = TensorboardLogger(log_dir)
+
         tb_logger.attach(trainer, log_handler=OutputHandler(tag="training", metric_names=["loss"]), event_name=Events.ITERATION_COMPLETED)
         tb_logger.attach(trainer, log_handler=OptimizerParamsHandler(optimizer), event_name=Events.ITERATION_STARTED)
         tb_logger.attach(evaluator, log_handler=OutputHandler(tag="validation", metric_names=list(metrics.keys()), another_engine=trainer), event_name=Events.EPOCH_COMPLETED)

--- a/train.py
+++ b/train.py
@@ -231,19 +231,19 @@ def train():
         tb_logger.attach(trainer, log_handler=OptimizerParamsHandler(optimizer), event_name=Events.ITERATION_STARTED)
         tb_logger.attach(evaluator, log_handler=OutputHandler(tag="validation", metric_names=list(metrics.keys()), another_engine=trainer), event_name=Events.EPOCH_COMPLETED)
 
-        checkpoint_handler = ModelCheckpoint(tb_logger.writer.log_dir, 'checkpoint', save_interval=1, n_saved=3)
+        checkpoint_handler = ModelCheckpoint(tb_logger.writer.logdir, 'checkpoint', save_interval=1, n_saved=3)
         trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpoint_handler, {'mymodel': getattr(model, 'module', model)})  # "getattr" take care of distributed encapsulation
 
-        torch.save(args, tb_logger.writer.log_dir + '/model_training_args.bin')
-        getattr(model, 'module', model).config.to_json_file(os.path.join(tb_logger.writer.log_dir, CONFIG_NAME))
-        tokenizer.save_vocabulary(tb_logger.writer.log_dir)
+        torch.save(args, tb_logger.writer.logdir + '/model_training_args.bin')
+        getattr(model, 'module', model).config.to_json_file(os.path.join(tb_logger.writer.logdir, CONFIG_NAME))
+        tokenizer.save_vocabulary(tb_logger.writer.logdir)
 
     # Run the training
     trainer.run(train_loader, max_epochs=args.n_epochs)
 
     # On the main process: close tensorboard logger and rename the last checkpoint (for easy re-loading with OpenAIGPTModel.from_pretrained method)
     if args.local_rank in [-1, 0] and args.n_epochs > 0:
-        os.rename(checkpoint_handler._saved[-1][1][-1], os.path.join(tb_logger.writer.log_dir, WEIGHTS_NAME))  # TODO: PR in ignite to have better access to saved file paths (cleaner)
+        os.rename(checkpoint_handler._saved[-1][1][-1], os.path.join(tb_logger.writer.logdir, WEIGHTS_NAME))  # TODO: PR in ignite to have better access to saved file paths (cleaner)
         tb_logger.close()
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -267,7 +267,5 @@ def train():
         os.rename(checkpoint_handler._saved[-1][1][-1], os.path.join(log_dir, WEIGHTS_NAME))  # TODO: PR in ignite to have better access to saved file paths (cleaner)
         tb_logger.close()
 
-
-
 if __name__ == "__main__":
     train()

--- a/train.py
+++ b/train.py
@@ -16,12 +16,14 @@ from ignite.handlers import ModelCheckpoint
 from ignite.metrics import Accuracy, Loss, MetricsLambda, RunningAverage
 from ignite.contrib.handlers import ProgressBar, PiecewiseLinear
 from ignite.contrib.handlers.tensorboard_logger import TensorboardLogger, OutputHandler, OptimizerParamsHandler
-from pytorch_pretrained_bert import (OpenAIAdam, OpenAIGPTDoubleHeadsModel, OpenAIGPTTokenizer,
-                                     GPT2DoubleHeadsModel, GPT2Tokenizer, WEIGHTS_NAME, CONFIG_NAME)
+from pytorch_transformers import (AdamW, OpenAIGPTDoubleHeadsModel, OpenAIGPTTokenizer,
+                                  GPT2DoubleHeadsModel, GPT2Tokenizer, WEIGHTS_NAME, CONFIG_NAME)
 
 from utils import get_dataset
 
 SPECIAL_TOKENS = ["<bos>", "<eos>", "<speaker1>", "<speaker2>", "<pad>"]
+ATTR_TO_SPECIAL_TOKEN = {'bos_token': '<bos>', 'eos_token': '<eos>', 'pad_token': '<pad>',
+                         'additional_special_tokens': ('<speaker1>', '<speaker2>')}
 MODEL_INPUTS = ["input_ids", "mc_token_ids", "lm_labels", "mc_labels", "token_type_ids"]
 PADDED_INPUTS = ["input_ids", "lm_labels", "token_type_ids"]
 
@@ -37,7 +39,7 @@ def average_distributed_scalar(scalar, args):
 
 
 def pad_dataset(dataset, padding=0):
-    """ Pad the dataset. This could be optimized by defining a Dataset class and padd only batches but this is simpler. """
+    """ Pad the dataset. This could be optimized by defining a Dataset class and padding at the batch level, but this is simpler. """
     max_l = max(len(x) for x in dataset["input_ids"])
     for name in PADDED_INPUTS:
         dataset[name] = [x + [padding if name != "lm_labels" else -1] * (max_l - len(x)) for x in dataset[name]]
@@ -45,7 +47,7 @@ def pad_dataset(dataset, padding=0):
 
 
 def build_input_from_segments(persona, history, reply, tokenizer, lm_labels=False, with_eos=True):
-    """ Build a sequence of input from 3 segments: persona, history and last reply """
+    """ Build a sequence of input from 3 segments: persona, history and last reply. """
     bos, eos, speaker1, speaker2 = tokenizer.convert_tokens_to_ids(SPECIAL_TOKENS[:-1])
 
     instance = {}
@@ -58,7 +60,7 @@ def build_input_from_segments(persona, history, reply, tokenizer, lm_labels=Fals
     instance["lm_labels"] = [-1] * len(instance["input_ids"])
     if lm_labels:
         instance["lm_labels"] = ([-1] * sum(len(s) for s in sequence[:-1])) + [-1] + sequence[-1][1:]
-    return instance, sequence
+    return instance, sequence  # TODO: second arg is never used, delete it
 
 
 def get_data_loaders(args, tokenizer):
@@ -141,15 +143,20 @@ def train():
         args.device = torch.device("cuda", args.local_rank)
         torch.distributed.init_process_group(backend='nccl', init_method='env://')
 
-    logger.info("Prepare tokenizer, pretrained model and optimizer - add special tokens for fine-tuning")
-    tokenizer_class = GPT2Tokenizer if "gpt2" in args.model_checkpoint else OpenAIGPTTokenizer
+    logger.info("Prepare tokenizer, pretrained model and optimizer.")
+    tokenizer_class = GPT2Tokenizer if "gpt2" in args.model_checkpoint else OpenAIGPTTokenizer # cant use Autotokenizer because checkpoint could be a Path
     tokenizer = tokenizer_class.from_pretrained(args.model_checkpoint)
+
+
     model_class = GPT2DoubleHeadsModel if "gpt2" in args.model_checkpoint else OpenAIGPTDoubleHeadsModel
     model = model_class.from_pretrained(args.model_checkpoint)
-    tokenizer.set_special_tokens(SPECIAL_TOKENS)
-    model.set_num_special_tokens(len(SPECIAL_TOKENS))
     model.to(args.device)
-    optimizer = OpenAIAdam(model.parameters(), lr=args.lr)
+    # Add special tokens if they are not already added
+    orig_num_tokens = len(tokenizer.encoder)
+    num_added_tokens = tokenizer.add_special_tokens(ATTR_TO_SPECIAL_TOKEN)  # returns 0 and doesn't add if they are already loaded
+    if num_added_tokens > 0:
+        model.resize_token_embeddings(new_num_tokens=orig_num_tokens + num_added_tokens) # use vocab_size after PR
+    optimizer = AdamW(model.parameters(), lr=args.lr, correct_bias=True)
 
     # Prepare model for FP16 and distributed training if needed (order is important, distributed should be the last)
     if args.fp16:
@@ -165,7 +172,11 @@ def train():
     def update(engine, batch):
         model.train()
         batch = tuple(input_tensor.to(args.device) for input_tensor in batch)
-        lm_loss, mc_loss = model(*batch)
+        input_ids, mc_token_ids, lm_labels, mc_labels, token_type_ids = batch
+        (lm_loss), (mc_loss), *_ = model(
+            input_ids, token_type_ids=token_type_ids, mc_token_ids=mc_token_ids,
+            mc_labels=mc_labels, lm_labels=lm_labels
+        )
         loss = (lm_loss * args.lm_coef + mc_loss * args.mc_coef) / args.gradient_accumulation_steps
         if args.fp16:
             with amp.scale_loss(loss, optimizer) as scaled_loss:
@@ -187,8 +198,10 @@ def train():
             batch = tuple(input_tensor.to(args.device) for input_tensor in batch)
             input_ids, mc_token_ids, lm_labels, mc_labels, token_type_ids = batch
             logger.info(tokenizer.decode(input_ids[0, -1, :].tolist()))
-            model_outputs = model(input_ids, mc_token_ids, token_type_ids=token_type_ids)
-            lm_logits, mc_logits = model_outputs[0], model_outputs[1]  # So we can also use GPT2 outputs
+            # if we dont send labels to model, it doesnt return losses
+            lm_logits, mc_logits, *_ = model(
+                input_ids, token_type_ids=token_type_ids, mc_token_ids=mc_token_ids,
+            )
             lm_logits_flat_shifted = lm_logits[..., :-1, :].contiguous().view(-1, lm_logits.size(-1))
             lm_labels_flat_shifted = lm_labels[..., 1:].contiguous().view(-1)
             return (lm_logits_flat_shifted, mc_logits), (lm_labels_flat_shifted, mc_labels)
@@ -210,7 +223,7 @@ def train():
     scheduler = PiecewiseLinear(optimizer, "lr", [(0, args.lr), (args.n_epochs * len(train_loader), 0.0)])
     trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
 
-    # Prepare metrics - note how we compute distributed metrics 
+    # Prepare metrics - note how we compute distributed metrics
     RunningAverage(output_transform=lambda x: x).attach(trainer, "loss")
     metrics = {"nll": Loss(torch.nn.CrossEntropyLoss(ignore_index=-1), output_transform=lambda x: (x[0][0], x[1][0])),
                "accuracy": Accuracy(output_transform=lambda x: (x[0][1], x[1][1]))}
@@ -227,23 +240,24 @@ def train():
         evaluator.add_event_handler(Events.COMPLETED, lambda _: pbar.log_message("Validation: %s" % pformat(evaluator.state.metrics)))
 
         tb_logger = TensorboardLogger(log_dir=None)
+        log_dir = tb_logger.writer.logdir  # to save typing
         tb_logger.attach(trainer, log_handler=OutputHandler(tag="training", metric_names=["loss"]), event_name=Events.ITERATION_COMPLETED)
         tb_logger.attach(trainer, log_handler=OptimizerParamsHandler(optimizer), event_name=Events.ITERATION_STARTED)
         tb_logger.attach(evaluator, log_handler=OutputHandler(tag="validation", metric_names=list(metrics.keys()), another_engine=trainer), event_name=Events.EPOCH_COMPLETED)
 
-        checkpoint_handler = ModelCheckpoint(tb_logger.writer.logdir, 'checkpoint', save_interval=1, n_saved=3)
-        trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpoint_handler, {'mymodel': getattr(model, 'module', model)})  # "getattr" take care of distributed encapsulation
+        checkpoint_handler = ModelCheckpoint(log_dir, 'checkpoint', save_interval=1, n_saved=3)
+        trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpoint_handler, {'mymodel': getattr(model, 'module', model)})  # "getattr" takes care of distributed encapsulation
 
-        torch.save(args, tb_logger.writer.logdir + '/model_training_args.bin')
-        getattr(model, 'module', model).config.to_json_file(os.path.join(tb_logger.writer.logdir, CONFIG_NAME))
-        tokenizer.save_vocabulary(tb_logger.writer.logdir)
+        torch.save(args, log_dir + '/model_training_args.bin')
+        getattr(model, 'module', model).config.to_json_file(os.path.join(log_dir, CONFIG_NAME))
+        tokenizer.save_pretrained(log_dir)
 
     # Run the training
     trainer.run(train_loader, max_epochs=args.n_epochs)
 
     # On the main process: close tensorboard logger and rename the last checkpoint (for easy re-loading with OpenAIGPTModel.from_pretrained method)
     if args.local_rank in [-1, 0] and args.n_epochs > 0:
-        os.rename(checkpoint_handler._saved[-1][1][-1], os.path.join(tb_logger.writer.logdir, WEIGHTS_NAME))  # TODO: PR in ignite to have better access to saved file paths (cleaner)
+        os.rename(checkpoint_handler._saved[-1][1][-1], os.path.join(log_dir, WEIGHTS_NAME))  # TODO: PR in ignite to have better access to saved file paths (cleaner)
         tb_logger.close()
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ import tempfile
 
 import torch
 
-from pytorch_pretrained_bert import cached_path
+from pytorch_transformers import cached_path
 
 PERSONACHAT_URL = "https://s3.amazonaws.com/datasets.huggingface.co/personachat/personachat_self_original.json"
 HF_FINETUNED_MODEL = "https://s3.amazonaws.com/models.huggingface.co/transfer-learning-chatbot/finetuned_chatbot_gpt.tar.gz"

--- a/utils.py
+++ b/utils.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2019-present, HuggingFace Inc.
 # All rights reserved. This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+from datetime import datetime
 import json
 import logging
 import os
 import tarfile
 import tempfile
+import socket
+
 
 import torch
 
@@ -88,3 +91,12 @@ class AttrDict(dict):
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
+
+
+def make_logdir(model_name: str):
+    """Create unique path to save results and checkpoints, e.g. runs/Sep22_19-45-59_gpu-7_gpt2"""
+    # Code copied from ignite repo
+    current_time = datetime.now().strftime('%b%d_%H-%M-%S')
+    logdir = os.path.join(
+        'runs', current_time + '_' + socket.gethostname() + '_' + model_name)
+    return logdir

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,6 @@ import tarfile
 import tempfile
 import socket
 
-
 import torch
 
 from pytorch_transformers import cached_path


### PR DESCRIPTION
### S3 Changes
In order to run `convai_evaluation.py` or `interact.py` on the existing checkpoint, we need a few changes:

1. adding vocab_size = 40483 to config.json
 - 	I tried to avoid changing this, but the embeddings won't load at the wrong size (40478), and sending `n_special` to the model doesn't do anything, so this seemed like the easiest route. I might be missing a cleaner way.
2. renaming some parameters in `pytorch_model.bin`
3. replace `special_tokens.txt` with `added_tokens.json`, containing the following

```
{"<bos>": 40478, "<eos>": 40479, "<speaker1>": 40480, "<speaker2>": 40481, "<pad>": 40482}
```
to ensure alignment.

Here is the updated [cache](https://www.dropbox.com/s/bt6n0kyqsrnyx3e/gpt_personachat_cache.tar.gz?dl=0)

### Code changes
* `train.py` always tries to add special tokens, then resizes embeddings if any special tokens were added, with the following logic:

```
orig_num_tokens = len(tokenizer.encoder)
num_added_tokens = tokenizer.add_special_tokens(SPECIAL_TOKENS_DICT)
if num_added_tokens > 0:
    model.resize_token_embeddings(new_num_tokens=orig_num_tokens + num_added_tokens)
```
* call to TensorboardLogger.writer.log_dir used to raise AttributeError, it's called `writer.logdir` on that repo's master now. requirements.txt reflects this.

* Switched `OpenAIAdam()` -> `AdamW(correct_bias=True)`. Did not change `PiecewiseLinearScheduler`. My reasoning was that   (a) old code warned that "t_total value of -1 results in schedule not being applied", from which I infer that PiecewiseLinear (from ignite) was doing all the scheduling (not the `schedule='warmup_linear'` kwarg in `OpenAIAdam`. Learning rates in tensorboards from before and after the change support this theory; they are identical and go straight down without warmup.

* I added one unittest in `test_tokenizers.py` to make sure I wasn't messing up the tokenizers.

* `convai_evaluation.py` supports GPT2 model checkpoints


### Sanity Check
TLDR: metrics and generations are similar but not identical after training for 1 epoch  (2 V100s,  FP16='O1').


**Before Change:**
- Validation: {'accuracy': 0.7413,
 'average_accuracy': 0.7368,
 'average_nll': 2.6829,
 'average_ppl': 14.6283,
 'nll': 2.6755}
- convai_evaluation: {'exs': 7801, 'hits@1': **0.737**, 'hits@5': 0.955, 'hits@10': 0.99, 'hits@100': 1.0}
- 44 mins

**After Change:**

- Validation: {'accuracy': 0.7657,
 'average_accuracy': 0.7582,
 'average_nll': 2.63606,
 'average_ppl': 13.9582,
 'nll': 2.6283}

- convai_evaluation: {'exs': 7801, 'hits@1': **0.758**, 'hits@5': 0.957, 'hits@10': 0.992, 'hits@100': 1.0}
- 42 mins

I don't have the full output, but hits@1 for the cached/competition model stays above 79 after the change.

### Unfinished
- update S3 and change `S3_PATH`
- `interact.py` for GPT2 (this is also broken before the change)

Feedback much appreciated!