### PR TITLE
Fixed type of interact.py's temperature argument from int to float

### DIFF
--- a/interact.py
+++ b/interact.py
@@ -100,7 +100,7 @@ def run():
     parser.add_argument("--max_length", type=int, default=20, help="Maximum length of the output utterances")
     parser.add_argument("--min_length", type=int, default=1, help="Minimum length of the output utterances")
     parser.add_argument("--seed", type=int, default=0, help="Seed")
-    parser.add_argument("--temperature", type=int, default=0.7, help="Sampling softmax temperature")
+    parser.add_argument("--temperature", type=float, default=0.7, help="Sampling softmax temperature")
     parser.add_argument("--top_k", type=int, default=0, help="Filter top-k tokens before sampling (<=0: no filtering)")
     parser.add_argument("--top_p", type=float, default=0.9, help="Nucleus filtering (top-p) before sampling (<=0.0: no filtering)")
     args = parser.parse_args()


### PR DESCRIPTION
Thanks for this amazing code!  I noticed a tiny type error and hope this helps.

The --temperature flag in interact.py has the type `int` but it's default value is a `float`.  I changed the type to float to match what it should be : ).
